### PR TITLE
3057 Replacing 'master' to 'HEAD' for default git commit

### DIFF
--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -52,7 +52,7 @@ def _checkout(cwd, repo, branch):
 
 def checkout(cwd, repo, branch=None):
     if branch is None:
-        branch = 'master'
+        branch = 'HEAD'
     try:
         return _checkout(cwd, repo, branch)
     except dbt.exceptions.CommandResultError as exc:

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -72,7 +72,7 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
     def _fetch_metadata(self, project, renderer) -> ProjectPackageMetadata:
         path = self._checkout()
-        if self.revision == 'master' and self.warn_unpinned:
+        if self.revision == 'HEAD' and self.warn_unpinned:
             warn_or_error(
                 'The git package "{}" is not pinned.\n\tThis can introduce '
                 'breaking changes into your project without warning!\n\nSee {}'
@@ -133,7 +133,7 @@ class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
     def resolved(self) -> GitPinnedPackage:
         requested = set(self.revisions)
         if len(requested) == 0:
-            requested = {'master'}
+            requested = {'HEAD'}
         elif len(requested) > 1:
             raise_dependency_error(
                 'git dependencies should contain exactly one version. '

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -104,7 +104,7 @@ class TestGitPackage(unittest.TestCase):
 
         a_pinned = a.resolved()
         self.assertEqual(a_pinned.name, 'http://example.com')
-        self.assertEqual(a_pinned.get_version(), 'master')
+        self.assertEqual(a_pinned.get_version(), 'HEAD')
         self.assertEqual(a_pinned.source_type(), 'git')
         self.assertIs(a_pinned.warn_unpinned, True)
 


### PR DESCRIPTION
resolves #3057

### Description

Moving from 'master' to 'HEAD' default branch in git

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
